### PR TITLE
AdobeHDS.php: List all missing extensions

### DIFF
--- a/AdobeHDS.php
+++ b/AdobeHDS.php
@@ -1764,14 +1764,19 @@
     }
 
   // Check for required extensions
-  $extensions = array(
+  $required_extensions = array(
       "bcmath",
       "curl",
       "SimpleXML"
   );
-  foreach ($extensions as $extension)
-      if (!extension_loaded($extension))
-          LogError("You don't have '$extension' extension installed. please install it before continuing.");
+
+  $missing_extensions = array_diff($required_extensions, get_loaded_extensions());
+
+  if ($missing_extensions)
+    {
+      $msg = "You have to install the following extension(s) to continue: '" . implode("', '", $missing_extensions) . "'";
+      LogError($msg);
+    }
 
   // Initialize classes
   $cc  = new cURL();


### PR DESCRIPTION
When more than one PHP extensions are missing, the script asks you to install the first missing extension, and says nothing about the other missing extensions. For example, if bcmath and curl are missing, it only asks you to install bcmath. This behavior can be misleading. This change makes the script list all missing extensions. 
