### PR TITLE
Honor http_proxy environment variable

### DIFF
--- a/AdobeHDS.php
+++ b/AdobeHDS.php
@@ -2129,6 +2129,12 @@
   $ad  = new AkamaiDecryptor();
   $f4f = new F4F();
 
+  // Honor http_proxy environment variable
+  if (isset($_ENV["http_proxy"])) {
+      $cc->proxy = $_ENV["http_proxy"];
+      $cc->fragProxy = true;
+  }
+
   // Process command line options
   if (isset($cli->params['unknown']))
       $baseFilename = $cli->params['unknown'][0];


### PR DESCRIPTION
A lot of programs (including ffmpeg), proxies their requests via an HTTP proxy if the environment variable `http_proxy` is set. This patch gives AdobeHDS.php the same ability.

Example usage:

```
$ export http_proxy=http://127.0.0.1:8118/
$ php AdobeHDS.php ...
```